### PR TITLE
Fixed props passing to SCLAlertHeader

### DIFF
--- a/src/components/SCLAlertHeader.js
+++ b/src/components/SCLAlertHeader.js
@@ -21,11 +21,11 @@ SCLAlertHeader.defaultProps = {
 
 function SCLAlertHeader(props) {
   return (
-    <View style={[styles.container, styles.headerContainerStyles]}>
+    <View style={[styles.container, props.headerContainerStyles]}>
       <View
         style={[
           styles.inner,
-          styles.headerInnerStyles,
+          props.headerInnerStyles,
           { backgroundColor: variables[`${props.theme}Background`] }
         ]}
       >


### PR DESCRIPTION
Fixed passing of props (`headerContainerStyles` and `headerInnerStyles`) to SCLAlertHeader component.

@rafaelmotta Please merge it ASAP.